### PR TITLE
Fixed getRowIdentifier bug

### DIFF
--- a/MOMCompound.class.php
+++ b/MOMCompound.class.php
@@ -227,11 +227,11 @@ class MOMCompound extends MOMBase
 	  */
 	protected function getRowIdentifier()
 	{
-		$identifier = '';
+		$identifier = [];
 		foreach (self::getCompoundKeys() as $key)
-			$identifier .= $this->{$key};
+			$identifier[] = $this->{$key};
 
-		return $identifier;
+		return json_encode($identifier);
 	}
 
 	/**


### PR DESCRIPTION
Fixed bug where getRowIdentifier() on MOMCompound would not always
return an unique identifier.

Example the following table
```
A_KEY	B_KEY	   DATA
   1	  12	some data
  11 	   2	Other data
```
With `COLUMN_COMPOUND_KEYS` sat to `A_KEY,B_KEY` MOMCompound would in both these rows produce an row identifier of `112`