### PR TITLE
Made protected fields ediatable

### DIFF
--- a/src/Compound.php
+++ b/src/Compound.php
@@ -133,14 +133,18 @@ class Compound extends Base
     {
         $values = [];
         $compoundKeys = self::getCompoundKeys();
-        foreach (static::$__mbDescriptions[get_called_class()] as $field) {
-            if (
-                !in_array($field['Field'], $compoundKeys) &&
-                !in_array($field['Default'], self::$__mbProtectedValueDefaults) &&
-                !in_array($field['Extra'], self::$__mbProtectedValueExtras)
-            ) {
-                $values[] = $this->escapeObjectPair($field['Field'], $field['Type']);
+        foreach (static::describe() as $field) {
+            $name = $field['Field'];
+
+            if (!isset($this->$name) || in_array($name, $compoundKeys)) {
+                continue;
             }
+
+            if (static::isFieldProtected($field['Field']) && isset($this->__mbOriginalValues[$name]) && $this->$name === $this->__mbOriginalValues[$name]) {
+                continue;
+            }
+
+            $values[] = $this->escapeObjectPair($field['Field'], $field['Type']);
         }
 
         return $values;
@@ -194,7 +198,7 @@ class Compound extends Base
     private function getKeyPairs()
     {
         $wheres = [];
-        $description = static::$__mbDescriptions[get_called_class()];
+        $description = static::describe();
         foreach (self::getCompoundKeys() as $key) {
             if (!isset($this->$key)) {
                 throw new BaseException(BaseException::COMPOUND_KEY_MISSING_VALUE, get_called_class() . '->' . __FUNCTION__ . ' failed to save object to database, ' . $key . ' is not set on object');

--- a/tests/CompoundTest.php
+++ b/tests/CompoundTest.php
@@ -1,212 +1,206 @@
 <?php
+
 namespace tests;
 
 use tests\classes\CompoundActual;
 
 class CompoundTest extends \PHPUnit\Framework\TestCase
 {
-	static $connection = NULL;
-	static $memcache = NULL;
-	static $skipTests = FALSE;
-	static $skipTestsMessage = '';
-	private static $autoIncrement = 1;
+    private static $connection = null;
+    private static $memcache = null;
+    private static $skipTests = false;
+    private static $skipTestsMessage = '';
+    private static $autoIncrement = 1;
 
-	public static function setUpBeforeClass(): void
-	{
-		try
-		{
-			self::$connection = Util::getConnection();
-			\Gyde\Mom\Base::setConnection(self::$connection, TRUE);
-			$sqls[] = 'DROP TABLE IF EXISTS '.CompoundActual::DB.'.'.CompoundActual::TABLE.';';
-			$sqls[] = 'CREATE TABLE '.CompoundActual::DB.'.'.CompoundActual::TABLE.' ('.
-				' `'.CompoundActual::COLUMN_KEY1.'` INT(10) UNSIGNED NOT NULL'.
-				', `'.CompoundActual::COLUMN_KEY2.'` INT(10) UNSIGNED NOT NULL'.
-				', `'.CompoundActual::COLUMN_KEY3.'` INT(10) UNSIGNED NOT NULL'.
-				', `'.CompoundActual::COLUMN_DEFAULT_VALUE.'` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\''.
-				', `'.CompoundActual::COLUMN_CREATED.'` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'.
-				', `'.CompoundActual::COLUMN_UPDATED.'` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'.
-				', `'.CompoundActual::COLUMN_UNIQUE.'` VARCHAR(32) CHARACTER SET ascii UNIQUE'.
-				', PRIMARY KEY (`'.CompoundActual::COLUMN_KEY1.'`,`'.CompoundActual::COLUMN_KEY2.'`,`'.CompoundActual::COLUMN_KEY3.'`)'.
-				') ENGINE = MYISAM;';
+    public static function setUpBeforeClass(): void
+    {
+        try {
+            self::$connection = Util::getConnection();
+            \Gyde\Mom\Base::setConnection(self::$connection, true);
+            $sqls[] = 'DROP TABLE IF EXISTS ' . CompoundActual::DB . '.' . CompoundActual::TABLE . ';';
+            $sqls[] = 'CREATE TABLE ' . CompoundActual::DB . '.' . CompoundActual::TABLE . ' (' .
+                ' `' . CompoundActual::COLUMN_KEY1 . '` INT(10) UNSIGNED NOT NULL' .
+                ', `' . CompoundActual::COLUMN_KEY2 . '` INT(10) UNSIGNED NOT NULL' .
+                ', `' . CompoundActual::COLUMN_KEY3 . '` INT(10) UNSIGNED NOT NULL' .
+                ', `' . CompoundActual::COLUMN_DEFAULT_VALUE . '` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\'' .
+                ', `' . CompoundActual::COLUMN_CREATED . '` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP' .
+                ', `' . CompoundActual::COLUMN_UPDATED . '` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP' .
+                ', `' . CompoundActual::COLUMN_UNIQUE . '` VARCHAR(32) CHARACTER SET ascii UNIQUE' .
+                ', PRIMARY KEY (`' . CompoundActual::COLUMN_KEY1 . '`,`' . CompoundActual::COLUMN_KEY2 . '`,`' . CompoundActual::COLUMN_KEY3 . '`)' .
+                ') ENGINE = MYISAM;';
 
-			foreach ($sqls as $sql)
-			{
-				$res = self::$connection->exec($sql);
-			}
-		}
-		catch (\PDOException $e)
-		{
-			self::$skipTests = TRUE;
-			self::$skipTestsMessage = $e->getMessage();
-		}
+            foreach ($sqls as $sql) {
+                $res = self::$connection->exec($sql);
+            }
+        } catch (\PDOException $e) {
+            self::$skipTests = true;
+            self::$skipTestsMessage = $e->getMessage();
+        }
 
-		self::$memcache = Util::getMemcache();
-		\Gyde\Mom\Base::setMemcache(self::$memcache, 300);
-	}
+        self::$memcache = Util::getMemcache();
+        \Gyde\Mom\Base::setMemcache(self::$memcache, 300);
+    }
 
-	public static function tearDownAfterClass(): void
-	{
-		self::$connection = Util::getConnection();
-		$sql =
-			'DROP TABLE '.CompoundActual::DB.'.'.CompoundActual::TABLE;
+    public static function tearDownAfterClass(): void
+    {
+        self::$connection = Util::getConnection();
+        $sql = 'DROP TABLE ' . CompoundActual::DB . '.' . CompoundActual::TABLE;
 
-		self::$connection->query($sql);
-		self::$memcache = new \Memcached($_SERVER['MEMCACHE_HOST']);
-		self::$memcache->flush();
-	}
+        self::$connection->query($sql);
+        self::$memcache = new \Memcached($_SERVER['MEMCACHE_HOST']);
+        self::$memcache->flush();
+    }
 
-	public function setUp(): void
-	{
-		if (self::$skipTests)
-		{
-			echo("\n".self::$skipTestsMessage."\n");
-			$this->markTestSkipped(self::$skipTestsMessage);
-		}
-	}
+    public function setUp(): void
+    {
+        if (self::$skipTests) {
+            echo("\n" . self::$skipTestsMessage . "\n");
+            $this->markTestSkipped(self::$skipTestsMessage);
+        }
+    }
 
-	private function uniqueKeys(): array
-	{
-		return [
-			CompoundActual::COLUMN_KEY1 => self::$autoIncrement++,
-			CompoundActual::COLUMN_KEY2 => self::$autoIncrement++,
-			CompoundActual::COLUMN_KEY3 => self::$autoIncrement++
-		];
-	}
+    private function uniqueKeys(): array
+    {
+        return [
+            CompoundActual::COLUMN_KEY1 => self::$autoIncrement++,
+            CompoundActual::COLUMN_KEY2 => self::$autoIncrement++,
+            CompoundActual::COLUMN_KEY3 => self::$autoIncrement++
+        ];
+    }
 
-	public function testSave()
-	{
-		$ids = $this->uniqueKeys();
+    public function testSave()
+    {
+        $ids = $this->uniqueKeys();
 
-		$object1 = new CompoundActual(self::$connection);
-		foreach ($ids as $key => $value) {
-			$object1->$key = $value;
-		}
-		$object1->unique = uniqid();
-		$object1->save();
-		$this->assertEquals($object1->state, 'READY');
+        $object1 = new CompoundActual(self::$connection);
+        foreach ($ids as $key => $value) {
+            $object1->$key = $value;
+        }
+        $object1->unique = uniqid();
+        $object1->save();
+        $this->assertEquals($object1->state, 'READY');
 
-		$object2 = CompoundActual::getByIds($ids);
-		$this->assertEquals($object1->key1, $object2->key1);
-		$this->assertEquals($object1->key2, $object2->key2);
-		$this->assertEquals($object1->key3, $object2->key3);
-		$this->assertEquals($object1->unique, $object2->unique);
+        $object2 = CompoundActual::getByIds($ids);
+        $this->assertEquals($object1->key1, $object2->key1);
+        $this->assertEquals($object1->key2, $object2->key2);
+        $this->assertEquals($object1->key3, $object2->key3);
+        $this->assertEquals($object1->unique, $object2->unique);
 
-		$object3 = new CompoundActual(self::$connection);
-		$object3->key1 = $object1->key1;
-		$object3->key2 = self::$autoIncrement++;
-		$object3->key3 = $object1->key3;
-		$object3->state = 'SET';
-		$object3->unique = uniqid();
-		$object3->save();
+        $object3 = new CompoundActual(self::$connection);
+        $object3->key1 = $object1->key1;
+        $object3->key2 = self::$autoIncrement++;
+        $object3->key3 = $object1->key3;
+        $object3->state = 'SET';
+        $object3->unique = uniqid();
+        $object3->save();
 
-		$this->assertEquals($object1->key1, $object3->key1);
-		$this->assertNotEquals($object1->key2, $object3->key2);
-		$this->assertEquals($object1->key3, $object3->key3);
-		$this->assertNotEquals($object1->unique, $object3->unique);
-	}
+        $this->assertEquals($object1->key1, $object3->key1);
+        $this->assertNotEquals($object1->key2, $object3->key2);
+        $this->assertEquals($object1->key3, $object3->key3);
+        $this->assertNotEquals($object1->unique, $object3->unique);
+    }
 
-	public function testDelete()
-	{
-		$ids = $this->uniqueKeys();
-		$object1 = new CompoundActual(self::$connection);
-		foreach ($ids as $key => $value) {
-			$object1->$key = $value;
-		}
-		$object1->unique = uniqid();
-		$object1->save();
+    public function testDelete()
+    {
+        $ids = $this->uniqueKeys();
+        $object1 = new CompoundActual(self::$connection);
+        foreach ($ids as $key => $value) {
+            $object1->$key = $value;
+        }
+        $object1->unique = uniqid();
+        $object1->save();
 
-		$object2 = CompoundActual::getByIds($ids);
-		$this->assertNotNull($object2);
-		$object2->delete();
+        $object2 = CompoundActual::getByIds($ids);
+        $this->assertNotNull($object2);
+        $object2->delete();
 
-		$object2 = CompoundActual::getByIds($ids);
+        $object2 = CompoundActual::getByIds($ids);
 
-		$this->assertNull($object2, 'Object should not be in database');
-	}
+        $this->assertNull($object2, 'Object should not be in database');
+    }
 
-	public function testStaticCacheSingleton()
-	{
-		$ids = $this->uniqueKeys();
-		$where = array();
+    public function testStaticCacheSingleton()
+    {
+        $ids = $this->uniqueKeys();
+        $where = array();
 
-		$object1 = new CompoundActual(self::$connection);
-		$object1->unique = uniqid();
-		foreach ($ids as $key => $id)
-		{
-			$object1->{$key} = $id;
-			$where[] = '`'.$key.'` = \''.$id.'\'';
-		}
-		$where = join(' AND ', $where);
-		$object1->save();
+        $object1 = new CompoundActual(self::$connection);
+        $object1->unique = uniqid();
+        foreach ($ids as $key => $id) {
+            $object1->$key = $id;
+            $where[] = '`' . $key . '` = \'' . $id . '\'';
+        }
+        $where = join(' AND ', $where);
+        $object1->save();
 
-		$object2 = CompoundActual::getByIds($ids);
-		$this->assertSame($object1, $object2);
+        $object2 = CompoundActual::getByIds($ids);
+        $this->assertSame($object1, $object2);
 
-		CompoundActual::flushStaticEntries();
+        CompoundActual::flushStaticEntries();
 
-		$object3 = CompoundActual::getByIds($ids);
-		$this->assertNotSame($object2, $object3);
+        $object3 = CompoundActual::getByIds($ids);
+        $this->assertNotSame($object2, $object3);
 
-		$object4 = CompoundActual::getByIds($ids);
-		$this->assertSame($object3, $object4);
+        $object4 = CompoundActual::getByIds($ids);
+        $this->assertSame($object3, $object4);
 
-		// All other get* methods (getOne included) goes through getAllByWhereGeneric()
-		// Meaning that if this test passes singletons should be ensured.
-		$object5 = CompoundActual::getOne($where);
-		$this->assertSame($object4, $object5);
-	}
+        // All other get* methods (getOne included) goes through getAllByWhereGeneric()
+        // Meaning that if this test passes singletons should be ensured.
+        $object5 = CompoundActual::getOne($where);
+        $this->assertSame($object4, $object5);
+    }
 
-	public function testProtectedFields()
-	{
-		$object = new CompoundActual();
-		foreach ($this->uniqueKeys() as $key => $value) {
-			$object->$key = $value;
-		}
-		$created1 = $object->created;
-		$updated1 = $object->updated;
+    public function testProtectedFields()
+    {
+        $object = new CompoundActual();
+        foreach ($this->uniqueKeys() as $key => $value) {
+            $object->$key = $value;
+        }
+        $created1 = $object->created;
+        $updated1 = $object->updated;
 
-		$object->save();
-		$created2 = $object->created;
-		$updated2 = $object->updated;
+        $object->save();
+        $created2 = $object->created;
+        $updated2 = $object->updated;
 
-		$this->assertSame(1, preg_match(Util::DATETIME_REGEX, $created2), 'Not valid datetime string');
-		$this->assertNotEquals($created1, $created2);
-		$this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated2), 'Not valid datetime string');
-		$this->assertNotEquals($updated1, $updated2);
+        $this->assertSame(1, preg_match(Util::DATETIME_REGEX, $created2), 'Not valid datetime string');
+        $this->assertNotEquals($created1, $created2);
+        $this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated2), 'Not valid datetime string');
+        $this->assertNotEquals($updated1, $updated2);
 
-		sleep(1);
-		$object->unique = uniqid();
-		$object->save();
-		$created3 = $object->created;
-		$updated3 = $object->updated;
+        sleep(1);
+        $object->unique = uniqid();
+        $object->save();
+        $created3 = $object->created;
+        $updated3 = $object->updated;
 
-		$this->assertEquals($created2, $created3);
-		$this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated3), 'Not valid datetime string');
-		$this->assertGreaterThan($updated2, $updated3);
-	}
+        $this->assertEquals($created2, $created3);
+        $this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated3), 'Not valid datetime string');
+        $this->assertGreaterThan($updated2, $updated3);
+    }
 
-	public function testProtectedFieldsOverwrite()
-	{
-		$newDate = '2000-01-01 13:37:00';
+    public function testProtectedFieldsOverwrite()
+    {
+        $newDate = '2000-01-01 13:37:00';
 
-		$object = new CompoundActual();
-		foreach ($this->uniqueKeys() as $key => $value) {
-			$object->$key = $value;
-		}
-		$object->created = $newDate;
-		$object->updated = $newDate;
-		$object->save();
+        $object = new CompoundActual();
+        foreach ($this->uniqueKeys() as $key => $value) {
+            $object->$key = $value;
+        }
+        $object->created = $newDate;
+        $object->updated = $newDate;
+        $object->save();
 
-		$this->assertEquals($newDate, $object->created);
-		$this->assertEquals($newDate, $object->updated);
+        $this->assertEquals($newDate, $object->created);
+        $this->assertEquals($newDate, $object->updated);
 
-		$newDate = '2000-01-02 13:37:00';
+        $newDate = '2000-01-02 13:37:00';
 
-		$object->created = $newDate;
-		$object->updated = $newDate;
-		$object->save();
+        $object->created = $newDate;
+        $object->updated = $newDate;
+        $object->save();
 
-		$this->assertEquals($newDate, $object->created);
-		$this->assertEquals($newDate, $object->updated);
-	}
+        $this->assertEquals($newDate, $object->created);
+        $this->assertEquals($newDate, $object->updated);
+    }
 }

--- a/tests/DefaultsTest.php
+++ b/tests/DefaultsTest.php
@@ -1,74 +1,73 @@
 <?php
+
 namespace tests;
 
 use tests\classes\DefaultActual;
 
 class DefaultTest extends \PHPUnit\Framework\TestCase
 {
-	static $connection = NULL;
-	static $memcache = NULL;
-	static $skipTests = FALSE;
-	static $skipTestsMessage = '';
+    private static $connection = null;
+    private static $memcache = null;
+    private static $skipTests = false;
+    private static $skipTestsMessage = '';
 
-	public static function setUpBeforeClass(): void
-	{
-		try {
-			self::$connection = Util::getConnection();
-			\Gyde\Mom\Base::setConnection(self::$connection, TRUE);
-			self::createTable(DefaultActual::DB, DefaultActual::TABLE);
-		} catch (\PDOException $e) {
-			self::$skipTests = TRUE;
-			self::$skipTestsMessage = $e->getMessage();
-		}
+    public static function setUpBeforeClass(): void
+    {
+        try {
+            self::$connection = Util::getConnection();
+            \Gyde\Mom\Base::setConnection(self::$connection, true);
+            self::createTable(DefaultActual::DB, DefaultActual::TABLE);
+        } catch (\PDOException $e) {
+            self::$skipTests = true;
+            self::$skipTestsMessage = $e->getMessage();
+        }
 
-		self::$memcache = Util::getMemcache();
-		\Gyde\Mom\Base::setMemcache(self::$memcache, 300);
-	}
+        self::$memcache = Util::getMemcache();
+        \Gyde\Mom\Base::setMemcache(self::$memcache, 300);
+    }
 
-	private static function createTable($dbName, $tableName)
-	{
-		$sqls[] = 'DROP TABLE IF EXISTS `'.$dbName.'`.`'.$tableName.'`;';
-		$sqls[] = 'CREATE TABLE `'.$dbName.'`.`'.$tableName.'` ('.
-			' `'.DefaultActual::COLUMN_PRIMARY_KEY.'` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY'.
-			', `'.DefaultActual::COLUMN_DEFAULT_VALUE.'` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\''.
-			', `'.DefaultActual::COLUMN_UPDATED.'` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL DEFAULT \'0000-00-00 00:00:00\''.
-			', `'.DefaultActual::COLUMN_UNIQUE.'` VARCHAR(32) CHARACTER SET ascii UNIQUE'.
-			') ENGINE = MYISAM;';
+    private static function createTable($dbName, $tableName)
+    {
+        $sqls[] = 'DROP TABLE IF EXISTS `' . $dbName . '`.`' . $tableName . '`;';
+        $sqls[] = 'CREATE TABLE `' . $dbName . '`.`' . $tableName . '` (' .
+            ' `' . DefaultActual::COLUMN_PRIMARY_KEY . '` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY' .
+            ', `' . DefaultActual::COLUMN_DEFAULT_VALUE . '` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\'' .
+            ', `' . DefaultActual::COLUMN_UPDATED . '` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL DEFAULT \'0000-00-00 00:00:00\'' .
+            ', `' . DefaultActual::COLUMN_UNIQUE . '` VARCHAR(32) CHARACTER SET ascii UNIQUE' .
+            ') ENGINE = MYISAM;';
 
-		foreach ($sqls as $sql)
-		{
-			$res = self::$connection->exec($sql);
-		}
-	}
+        foreach ($sqls as $sql) {
+            $res = self::$connection->exec($sql);
+        }
+    }
 
-	public static function tearDownAfterClass(): void
-	{
-		self::$connection = Util::getConnection();
-		$sqls[] =
-			'DROP TABLE `'.DefaultActual::DB.'`.`'.DefaultActual::TABLE.'`';
+    public static function tearDownAfterClass(): void
+    {
+        self::$connection = Util::getConnection();
+        $sqls[] = 'DROP TABLE `' . DefaultActual::DB . '`.`' . DefaultActual::TABLE . '`';
 
-		foreach ($sqls as $sql)
-			self::$connection->query($sql);
-		self::$memcache = Util::getMemcache();
-		self::$memcache->flush();
-	}
+        foreach ($sqls as $sql) {
+            self::$connection->query($sql);
+        }
+        self::$memcache = Util::getMemcache();
+        self::$memcache->flush();
+    }
 
-	public function setUp(): void
-	{
-		if (self::$skipTests)
-		{
-			echo("\n".self::$skipTestsMessage."\n");
-			$this->markTestSkipped(self::$skipTestsMessage);
-		}
-	}
+    public function setUp(): void
+    {
+        if (self::$skipTests) {
+            echo("\n" . self::$skipTestsMessage . "\n");
+            $this->markTestSkipped(self::$skipTestsMessage);
+        }
+    }
 
-	public function testDefault()
-	{
-		$object1 = new DefaultActual();
-		$object1->save();
-		$this->assertEquals($object1->updated, '0000-00-00 00:00:00');
-		$object1->unique = uniqid();
-		$object1->save();
-		$this->assertNotEquals($object1->updated, '0000-00-00 00:00:00');
-	}
+    public function testDefault()
+    {
+        $object1 = new DefaultActual();
+        $object1->save();
+        $this->assertEquals($object1->updated, '0000-00-00 00:00:00');
+        $object1->unique = uniqid();
+        $object1->save();
+        $this->assertNotEquals($object1->updated, '0000-00-00 00:00:00');
+    }
 }

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace tests;
 
 use tests\classes\FooBar;
@@ -7,91 +8,84 @@ use tests\classes\Bar;
 
 class ExtensionTest extends \PHPUnit\Framework\TestCase
 {
-	static $connection = NULL;
-	static $memcache = NULL;
-	static $skipTests = FALSE;
-	static $skipTestsMessage = '';
+    private static $connection = null;
+    private static $memcache = null;
+    private static $skipTests = false;
+    private static $skipTestsMessage = '';
 
-	public static function setUpBeforeClass(): void
-	{
-		FooBar::setDbName('mom');
-		try
-		{
-			self::$connection = Util::getConnection();
-			\Gyde\Mom\Base::setConnection(self::$connection, TRUE);
-			self::createTable(Foo::getDbName(), Foo::TABLE, Foo::COLUMN_PRIMARY_KEY);
-			self::createTable(Bar::getDbName(), Bar::TABLE, Bar::COLUMN_PRIMARY_KEY);
-		}
-		catch (\PDOException $e)
-		{
-			self::$skipTests = TRUE;
-			self::$skipTestsMessage = $e->getMessage();
-		}
+    public static function setUpBeforeClass(): void
+    {
+        FooBar::setDbName('mom');
+        try {
+            self::$connection = Util::getConnection();
+            \Gyde\Mom\Base::setConnection(self::$connection, true);
+            self::createTable(Foo::getDbName(), Foo::TABLE, Foo::COLUMN_PRIMARY_KEY);
+            self::createTable(Bar::getDbName(), Bar::TABLE, Bar::COLUMN_PRIMARY_KEY);
+        } catch (\PDOException $e) {
+            self::$skipTests = true;
+            self::$skipTestsMessage = $e->getMessage();
+        }
 
-		self::$memcache = Util::getMemcache();
-		\Gyde\Mom\Base::setMemcache(self::$memcache, 300);
-	}
+        self::$memcache = Util::getMemcache();
+        \Gyde\Mom\Base::setMemcache(self::$memcache, 300);
+    }
 
-	private static function createTable($dbName, $tableName, $primaryKey)
-	{
-		$sqls[] = 'DROP TABLE IF EXISTS `'.$dbName.'`.`'.$tableName.'`;';
-		$sqls[] = 'CREATE TABLE `'.$dbName.'`.`'.$tableName.'` ('.
-			' `'.$primaryKey.'` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY'.
-			', `state` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\''.
-			', `updated` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'.
-			', `unique` VARCHAR(32) CHARACTER SET ascii UNIQUE'.
-			') ENGINE = InnoDB;';
+    private static function createTable($dbName, $tableName, $primaryKey)
+    {
+        $sqls[] = 'DROP TABLE IF EXISTS `' . $dbName . '`.`' . $tableName . '`;';
+        $sqls[] = 'CREATE TABLE `' . $dbName . '`.`' . $tableName . '` (' .
+            ' `' . $primaryKey . '` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY' .
+            ', `state` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\'' .
+            ', `updated` TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP' .
+            ', `unique` VARCHAR(32) CHARACTER SET ascii UNIQUE' .
+            ') ENGINE = InnoDB;';
 
-		foreach ($sqls as $sql)
-		{
-			$res = self::$connection->exec($sql);
-		}
-	}
+        foreach ($sqls as $sql) {
+            $res = self::$connection->exec($sql);
+        }
+    }
 
-	public static function tearDownAfterClass(): void
-	{
-		self::$connection = Util::getConnection();
-		$sqls[] =
-			'DROP TABLE `'.Foo::getDbName().'`.`'.Foo::TABLE.'`';
-		$sqls[] =
-			'DROP TABLE `'.Bar::getDbName().'`.`'.Bar::TABLE.'`';
+    public static function tearDownAfterClass(): void
+    {
+        self::$connection = Util::getConnection();
+        $sqls[] =
+            'DROP TABLE `' . Foo::getDbName() . '`.`' . Foo::TABLE . '`';
+        $sqls[] =
+            'DROP TABLE `' . Bar::getDbName() . '`.`' . Bar::TABLE . '`';
 
-		foreach ($sqls as $sql)
-			self::$connection->query($sql);
-		self::$memcache = new \Memcached($_SERVER['MEMCACHE_HOST']);
-		self::$memcache->flush();
-	}
+        foreach ($sqls as $sql) {
+            self::$connection->query($sql);
+        }
+        self::$memcache = new \Memcached($_SERVER['MEMCACHE_HOST']);
+        self::$memcache->flush();
+    }
 
-	public function setUp(): void
-	{
-		if (self::$skipTests)
-		{
-			echo("\n".self::$skipTestsMessage."\n");
-			$this->markTestSkipped(self::$skipTestsMessage);
-		}
-		else
-		{
-		}
-	}
+    public function setUp(): void
+    {
+        if (self::$skipTests) {
+            echo("\n" . self::$skipTestsMessage . "\n");
+            $this->markTestSkipped(self::$skipTestsMessage);
+        }
+    }
 
-	public function testSave()
-	{
-		$object1 = new classes\Foo();
-		$object1->unique = uniqid();
-		$object1->save();
-		$this->assertEquals($object1->state, 'READY');
+    public function testSave()
+    {
+        $object1 = new classes\Foo();
+        $object1->unique = uniqid();
+        $object1->save();
+        $this->assertEquals($object1->state, 'READY');
 
-		$object2 = classes\Foo::getById($object1->foo_id);
-		$this->assertEquals($object1->foo_id, $object2->foo_id);
-		$this->assertEquals($object1->state, $object2->state);
-		$this->assertEquals($object1->updated, $object2->updated);
-		$this->assertEquals($object1->unique, $object2->unique);
+        $object2 = classes\Foo::getById($object1->foo_id);
+        $this->assertEquals($object1->foo_id, $object2->foo_id);
+        $this->assertEquals($object1->state, $object2->state);
+        $this->assertEquals($object1->updated, $object2->updated);
+        $this->assertEquals($object1->unique, $object2->unique);
 
-		$object3 = new classes\Bar();
-		$object3->state = 'SET';
-		$object3->unique = uniqid();
-		$object3->save();
+        $object3 = new classes\Bar();
+        $object3->state = 'SET';
+        $object3->unique = uniqid();
+        $object3->save();
 
-		$this->assertEquals($object3->state, 'SET');
-	}
+        $this->assertEquals($object3->state, 'SET');
+    }
 }

--- a/tests/SimpleTest.php
+++ b/tests/SimpleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace tests;
 
 use tests\classes\SimpleActual;
@@ -6,347 +7,339 @@ use tests\classes\SimpleActual2;
 
 class SimpleTest extends \PHPUnit\Framework\TestCase
 {
-	static $connection = NULL;
-	static $memcache = NULL;
-	static $skipTests = FALSE;
-	static $skipTestsMessage = '';
+    private static $connection = null;
+    private static $memcache = null;
+    private static $skipTests = false;
+    private static $skipTestsMessage = '';
 
-	public static function setUpBeforeClass(): void
-	{
-		try
-		{
-			self::$connection = Util::getConnection();
-			\Gyde\Mom\Base::setConnection(self::$connection, TRUE);
-			self::createTable(SimpleActual::DB, SimpleActual::TABLE);
-			self::createTable(SimpleActual2::DB.'2', SimpleActual2::TABLE); }
-		catch (\PDOException $e)
-		{
-			self::$skipTests = TRUE;
-			self::$skipTestsMessage = $e->getMessage();
-		}
-
-		self::$memcache = Util::getMemcache();
-		\Gyde\Mom\Base::setMemcache(self::$memcache, 300);
-	}
-
-	private static function createTable($dbName, $tableName)
-	{
-		$sqls[] = 'DROP TABLE IF EXISTS `'.$dbName.'`.`'.$tableName.'`';
-		$sqls[] = 'CREATE TABLE `'.$dbName.'`.`'.$tableName.'` ('.
-			' `'.SimpleActual::COLUMN_PRIMARY_KEY.'` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY'.
-			', `'.SimpleActual::COLUMN_DEFAULT_VALUE.'` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\''.
-			', `'.SimpleActual::COLUMN_CREATED.'` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP'.
-			', `'.SimpleActual::COLUMN_UPDATED.'` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'.
-			', `'.SimpleActual::COLUMN_IS_IT_ON.'` BOOLEAN DEFAULT 0'.
-			', `'.SimpleActual::COLUMN_UNIQUE.'` VARCHAR(32) CHARACTER SET ascii UNIQUE'.
-			') ENGINE = MYISAM';
-
-		foreach ($sqls as $sql)
-		{
-			$res = self::$connection->exec($sql);
-		}
-	}
-
-	public static function tearDownAfterClass(): void
-	{
-		self::$connection = Util::getConnection();
-		$sqls[] =
-			'DROP TABLE `'.SimpleActual::DB.'`.`'.SimpleActual::TABLE.'`';
-		$sqls[] =
-			'DROP TABLE `'.SimpleActual::DB.'2`.`'.SimpleActual2::TABLE.'`';
-
-		foreach ($sqls as $sql) {
-			self::$connection->query($sql);
+    public static function setUpBeforeClass(): void
+    {
+        try {
+            self::$connection = Util::getConnection();
+            \Gyde\Mom\Base::setConnection(self::$connection, true);
+            self::createTable(SimpleActual::DB, SimpleActual::TABLE);
+            self::createTable(SimpleActual2::DB . '2', SimpleActual2::TABLE);
+        } catch (\PDOException $e) {
+            self::$skipTests = true;
+            self::$skipTestsMessage = $e->getMessage();
         }
-		self::$memcache = Util::getMemcache();
-		self::$memcache->flush();
-	}
 
-	public function setUp(): void
-	{
-		if (self::$skipTests)
-		{
-			echo("\n".self::$skipTestsMessage."\n");
-			$this->markTestSkipped(self::$skipTestsMessage);
-		}
-	}
-	public function testSave()
-	{
-		$object1 = new SimpleActual();
-		$object1->unique = uniqid();
-		$this->assertEquals($object1->getSerializeTimestamp(), 0);
-		$this->assertEquals($object1->isNew(), true);
-		$object1->save();
-		$this->assertEquals($object1->state, 'READY');
-		$this->assertGreaterThan(0, $object1->getSerializeTimestamp());
-		$this->assertEquals($object1->isNew(), false);
+        self::$memcache = Util::getMemcache();
+        \Gyde\Mom\Base::setMemcache(self::$memcache, 300);
+    }
 
-		$object2 = SimpleActual::getById($object1->primary_key);
-		$this->assertGreaterThan(0, $object2->getSerializeTimestamp());
-		$this->assertEquals($object1->getSerializeTimestamp(), $object2->getSerializeTimestamp());
-		$this->assertEquals($object1->primary_key, $object2->primary_key);
-		$this->assertEquals($object1->state, $object2->state);
-		$this->assertEquals($object1->created, $object2->created);
-		$this->assertEquals($object1->unique, $object2->unique);
+    private static function createTable($dbName, $tableName)
+    {
+        $sqls[] = 'DROP TABLE IF EXISTS `' . $dbName . '`.`' . $tableName . '`';
+        $sqls[] = 'CREATE TABLE `' . $dbName . '`.`' . $tableName . '` (' .
+            ' `' . SimpleActual::COLUMN_PRIMARY_KEY . '` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY' .
+            ', `' . SimpleActual::COLUMN_DEFAULT_VALUE . '` ENUM(\'READY\',\'SET\',\'GO\') NOT NULL DEFAULT \'READY\'' .
+            ', `' . SimpleActual::COLUMN_CREATED . '` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP' .
+            ', `' . SimpleActual::COLUMN_UPDATED . '` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP' .
+            ', `' . SimpleActual::COLUMN_IS_IT_ON . '` BOOLEAN DEFAULT 0' .
+            ', `' . SimpleActual::COLUMN_UNIQUE . '` VARCHAR(32) CHARACTER SET ascii UNIQUE' .
+            ') ENGINE = MYISAM';
 
-		sleep(1);
+        foreach ($sqls as $sql) {
+            $res = self::$connection->exec($sql);
+        }
+    }
 
-		$object3 = new SimpleActual();
-		$object3->state = 'SET';
-		$object3->unique = uniqid();
-		$object3->save();
+    public static function tearDownAfterClass(): void
+    {
+        self::$connection = Util::getConnection();
+        $sqls[] = 'DROP TABLE `' . SimpleActual::DB . '`.`' . SimpleActual::TABLE . '`';
+        $sqls[] = 'DROP TABLE `' . SimpleActual::DB . '2`.`' . SimpleActual2::TABLE . '`';
 
-		$this->assertGreaterThan(0, $object3->getSerializeTimestamp());
-		$this->assertNotEquals($object2->getSerializeTimestamp(), $object3->getSerializeTimestamp());
-		$this->assertNotEquals($object2->primary_key, $object3->primary_key);
-		$this->assertNotEquals($object2->state, $object3->state);
-		$this->assertNotEquals($object2->created, $object3->created);
-		$this->assertNotEquals($object2->unique, $object3->unique);
-	}
+        foreach ($sqls as $sql) {
+            self::$connection->query($sql);
+        }
+        self::$memcache = Util::getMemcache();
+        self::$memcache->flush();
+    }
 
-	public function testLimit()
-	{
-		$objects = SimpleActual::getAll(null, false, 1);
-		$this->assertEquals(1, count($objects));
-	}
+    public function setUp(): void
+    {
+        if (self::$skipTests) {
+            echo("\n" . self::$skipTestsMessage . "\n");
+            $this->markTestSkipped(self::$skipTestsMessage);
+        }
+    }
+    public function testSave()
+    {
+        $object1 = new SimpleActual();
+        $object1->unique = uniqid();
+        $this->assertEquals($object1->getSerializeTimestamp(), 0);
+        $this->assertEquals($object1->isNew(), true);
+        $object1->save();
+        $this->assertEquals($object1->state, 'READY');
+        $this->assertGreaterThan(0, $object1->getSerializeTimestamp());
+        $this->assertEquals($object1->isNew(), false);
 
-	public function testDuplicateKey()
-	{
-		$objects = SimpleActual::getAll(null, false, 1);
-		$object1 = reset($objects);
+        $object2 = SimpleActual::getById($object1->primary_key);
+        $this->assertGreaterThan(0, $object2->getSerializeTimestamp());
+        $this->assertEquals($object1->getSerializeTimestamp(), $object2->getSerializeTimestamp());
+        $this->assertEquals($object1->primary_key, $object2->primary_key);
+        $this->assertEquals($object1->state, $object2->state);
+        $this->assertEquals($object1->created, $object2->created);
+        $this->assertEquals($object1->unique, $object2->unique);
 
-		try {
-			$object2 = new SimpleActual();
-			$object2->state = 'SET';
-			$object2->unique = $object1->unique;
-			$object2->save();
-		} catch (\Gyde\Mom\BaseException $e) {
-			$this->assertEquals($e->getCode(), \Gyde\Mom\BaseException::OBJECT_DUPLICATED_ENTRY);
-		}
-	}
+        sleep(1);
 
-	public function testGetAll()
-	{
-		$objects = SimpleActual::getAll();
-		$this->assertEquals(2, count($objects));
-	}
+        $object3 = new SimpleActual();
+        $object3->state = 'SET';
+        $object3->unique = uniqid();
+        $object3->save();
 
-	public function testGetAllByWhere()
-	{
-		$objects = SimpleActual::getByState(SimpleActual::STATE_SET);
-		$this->assertEquals(1, count($objects));
-	}
+        $this->assertGreaterThan(0, $object3->getSerializeTimestamp());
+        $this->assertNotEquals($object2->getSerializeTimestamp(), $object3->getSerializeTimestamp());
+        $this->assertNotEquals($object2->primary_key, $object3->primary_key);
+        $this->assertNotEquals($object2->state, $object3->state);
+        $this->assertNotEquals($object2->created, $object3->created);
+        $this->assertNotEquals($object2->unique, $object3->unique);
+    }
 
-	public function testGetAllLimit()
-	{
-		$objects = SimpleActual::getAll(NULL, FALSE, 1, 1);
-		$this->assertEquals(1, count($objects));
-	}
+    public function testLimit()
+    {
+        $objects = SimpleActual::getAll(null, false, 1);
+        $this->assertEquals(1, count($objects));
+    }
 
-	public function testClone()
-	{
-		$object1 = new SimpleActual();
-		$object1->state = SimpleActual::STATE_GO;
-		$object1->unique = uniqid();
-		$object1->save();
+    public function testDuplicateKey()
+    {
+        $objects = SimpleActual::getAll(null, false, 1);
+        $object1 = reset($objects);
 
-		sleep(1);
+        try {
+            $object2 = new SimpleActual();
+            $object2->state = 'SET';
+            $object2->unique = $object1->unique;
+            $object2->save();
+        } catch (\Gyde\Mom\BaseException $e) {
+            $this->assertEquals($e->getCode(), \Gyde\Mom\BaseException::OBJECT_DUPLICATED_ENTRY);
+        }
+    }
 
-		$object2 = clone $object1;
-		$object2->unique = uniqid();
-		$object2->save();
+    public function testGetAll()
+    {
+        $objects = SimpleActual::getAll();
+        $this->assertEquals(2, count($objects));
+    }
 
-		$this->assertNotEquals($object1->primary_key, $object2->primary_key);
-		$this->assertEquals($object1->state, $object2->state);
-		$this->assertNotEquals($object1->created, $object2->created);
-		$this->assertNotEquals($object1->unique, $object2->unique);
-		$this->assertGreaterThan($object1->getSerializeTimestamp(), $object2->getSerializeTimestamp());
-	}
+    public function testGetAllByWhere()
+    {
+        $objects = SimpleActual::getByState(SimpleActual::STATE_SET);
+        $this->assertEquals(1, count($objects));
+    }
 
-	public function testUnique()
-	{
-		$object1 = new SimpleActual();
-		$object1->unique = uniqid();
-		$object1->save();
+    public function testGetAllLimit()
+    {
+        $objects = SimpleActual::getAll(null, false, 1, 1);
+        $this->assertEquals(1, count($objects));
+    }
 
-		$object2 = SimpleActual::getByUnique($object1->unique);
+    public function testClone()
+    {
+        $object1 = new SimpleActual();
+        $object1->state = SimpleActual::STATE_GO;
+        $object1->unique = uniqid();
+        $object1->save();
 
-		$this->assertEquals($object1->primary_key, $object2->primary_key);
-		$this->assertEquals($object1->state, $object2->state);
-		$this->assertEquals($object1->created, $object2->created);
-		$this->assertEquals($object1->unique, $object2->unique);
-	}
+        sleep(1);
 
-	public function testSetDbName()
-	{
-		$objects = SimpleActual::getAll();
-		$this->assertCount(5, $objects);
+        $object2 = clone $object1;
+        $object2->unique = uniqid();
+        $object2->save();
 
-		SimpleActual2::setDbName(SimpleActual::DB.'2');
-		$this->assertEquals(SimpleActual::getDbName(), 'mom');
-		$this->assertEquals(SimpleActual2::getDbName(), 'mom2');
+        $this->assertNotEquals($object1->primary_key, $object2->primary_key);
+        $this->assertEquals($object1->state, $object2->state);
+        $this->assertNotEquals($object1->created, $object2->created);
+        $this->assertNotEquals($object1->unique, $object2->unique);
+        $this->assertGreaterThan($object1->getSerializeTimestamp(), $object2->getSerializeTimestamp());
+    }
 
-		$objects = SimpleActual2::getAll();
-		$this->assertCount(0, $objects);
+    public function testUnique()
+    {
+        $object1 = new SimpleActual();
+        $object1->unique = uniqid();
+        $object1->save();
 
-		$object1 = new SimpleActual2();
-		$object1->unique = uniqid();
-		$object1->save();
+        $object2 = SimpleActual::getByUnique($object1->unique);
 
-		$objects = SimpleActual2::getAll();
-		$this->assertCount(1, $objects);
+        $this->assertEquals($object1->primary_key, $object2->primary_key);
+        $this->assertEquals($object1->state, $object2->state);
+        $this->assertEquals($object1->created, $object2->created);
+        $this->assertEquals($object1->unique, $object2->unique);
+    }
 
-		SimpleActual::setDbName(NULL);
-	}
+    public function testSetDbName()
+    {
+        $objects = SimpleActual::getAll();
+        $this->assertCount(5, $objects);
 
-	/**
-	  * Test memcache on user created memcache methods
-	  * Uses memcache and static flush functions directly
-	  */
-	public function testMemcache()
-	{
-		// Locate some items we can cache
-		$uniqueKeys = [];
-		foreach ($objects = SimpleActual::getAll() as $object)
-		{
-			$uniqueKeys[] = $object->{SimpleActual::COLUMN_UNIQUE};
-		}
+        SimpleActual2::setDbName(SimpleActual::DB . '2');
+        $this->assertEquals(SimpleActual::getDbName(), 'mom');
+        $this->assertEquals(SimpleActual2::getDbName(), 'mom2');
 
-		/**
-		  * Make sure the memcache is empty and fetch all the objects using a
-		  * user created memcaching method
-		  * This tests PDO connection when objects are unserialized
-		  */
-		self::$memcache->flush();
-		$object = null;
-		foreach ($uniqueKeys as $uniqueKey)
-		{
-			$object1 = SimpleActual::getByUniqueMemcached($uniqueKey);
-		}
-		// Unset the description cache in MOM
-		$object1->unDescribe();
-		// Flush all the objects from the memcache
-		$object1::flushStaticEntries();
+        $objects = SimpleActual2::getAll();
+        $this->assertCount(0, $objects);
 
-		// Refetch the objects from the memcache
-		foreach ($uniqueKeys as $uniqueKey)
-		{
-			$object2 = SimpleActual::getByUniqueMemcached($uniqueKey);
-		}
+        $object1 = new SimpleActual2();
+        $object1->unique = uniqid();
+        $object1->save();
+
+        $objects = SimpleActual2::getAll();
+        $this->assertCount(1, $objects);
+
+        SimpleActual::setDbName(null);
+    }
+
+    /**
+      * Test memcache on user created memcache methods
+      * Uses memcache and static flush functions directly
+      */
+    public function testMemcache()
+    {
+        // Locate some items we can cache
+        $uniqueKeys = [];
+        foreach ($objects = SimpleActual::getAll() as $object) {
+            $uniqueKeys[] = $object->{SimpleActual::COLUMN_UNIQUE};
+        }
+
+        /**
+          * Make sure the memcache is empty and fetch all the objects using a
+          * user created memcaching method
+          * This tests PDO connection when objects are unserialized
+          */
+        self::$memcache->flush();
+        $object = null;
+        foreach ($uniqueKeys as $uniqueKey) {
+            $object1 = SimpleActual::getByUniqueMemcached($uniqueKey);
+        }
+        // Unset the description cache in MOM
+        $object1->unDescribe();
+        // Flush all the objects from the memcache
+        $object1::flushStaticEntries();
+
+        // Refetch the objects from the memcache
+        foreach ($uniqueKeys as $uniqueKey) {
+            $object2 = SimpleActual::getByUniqueMemcached($uniqueKey);
+        }
 
         $this->assertEquals($object1, $object2);
-	}
+    }
 
-	public function testDelete()
-	{
-		$objects = SimpleActual::getAll();
-		$this->assertCount(5, $objects);
-		foreach ($objects as $object)
-			$object->delete();
+    public function testDelete()
+    {
+        $objects = SimpleActual::getAll();
+        $this->assertCount(5, $objects);
+        foreach ($objects as $object) {
+            $object->delete();
+        }
 
-		$objects = SimpleActual::getAll();
+        $objects = SimpleActual::getAll();
 
-		$this->assertCount(0, $objects);
-	}
+        $this->assertCount(0, $objects);
+    }
 
-	public function testAllowNull()
-	{
-		$object = SimpleActual::getById('sdfasdfasdf', true);
-		$this->assertEquals($object, null);
-	}
+    public function testAllowNull()
+    {
+        $object = SimpleActual::getById('sdfasdfasdf', true);
+        $this->assertEquals($object, null);
+    }
 
-	public function testStaticCacheSingleton()
-	{
-		$object1 = new SimpleActual();
-		$object1->{SimpleActual::COLUMN_UNIQUE} = uniqid();
-		$object1->save();
+    public function testStaticCacheSingleton()
+    {
+        $object1 = new SimpleActual();
+        $object1->{SimpleActual::COLUMN_UNIQUE} = uniqid();
+        $object1->save();
 
-		$id = $object1->{SimpleActual::COLUMN_PRIMARY_KEY};
+        $id = $object1->{SimpleActual::COLUMN_PRIMARY_KEY};
 
-		$object2 = SimpleActual::getById($id);
-		$this->assertSame($object1, $object2);
+        $object2 = SimpleActual::getById($id);
+        $this->assertSame($object1, $object2);
 
-		SimpleActual::flushStaticEntries();
+        SimpleActual::flushStaticEntries();
 
-		$object3 = SimpleActual::getById($id);
-		$this->assertNotSame($object2, $object3);
+        $object3 = SimpleActual::getById($id);
+        $this->assertNotSame($object2, $object3);
 
-		$object4 = SimpleActual::getById($id);
-		$this->assertSame($object3, $object4);
+        $object4 = SimpleActual::getById($id);
+        $this->assertSame($object3, $object4);
 
-		// All other get* methods (getOne included) goes through getAllByWhereGeneric()
-		// Meaning that if this test passes singletons should be ensured.
-		$object5 = SimpleActual::getOne('`'.SimpleActual::COLUMN_PRIMARY_KEY.'` = \''.$id.'\'');
-		$this->assertSame($object4, $object5);
-	}
+        // All other get* methods (getOne included) goes through getAllByWhereGeneric()
+        // Meaning that if this test passes singletons should be ensured.
+        $object5 = SimpleActual::getOne('`' . SimpleActual::COLUMN_PRIMARY_KEY . '` = \'' . $id . '\'');
+        $this->assertSame($object4, $object5);
+    }
 
-	public function testBoolean()
-	{
-		$object1 = new SimpleActual();
-		$object1->{SimpleActual::COLUMN_UNIQUE} = uniqid();
-		$object1->{SimpleActual::COLUMN_IS_IT_ON} = false;
-		$object1->save();
-		$this->assertEquals($object1->{SimpleActual::COLUMN_IS_IT_ON}, 0);
+    public function testBoolean()
+    {
+        $object1 = new SimpleActual();
+        $object1->{SimpleActual::COLUMN_UNIQUE} = uniqid();
+        $object1->{SimpleActual::COLUMN_IS_IT_ON} = false;
+        $object1->save();
+        $this->assertEquals($object1->{SimpleActual::COLUMN_IS_IT_ON}, 0);
 
-		$object2 = new SimpleActual();
-		$object2->{SimpleActual::COLUMN_UNIQUE} = uniqid();
-		$object2->{SimpleActual::COLUMN_IS_IT_ON} = true;
-		$object2->save();
-		$this->assertEquals($object2->{SimpleActual::COLUMN_IS_IT_ON}, 1);
-	}
+        $object2 = new SimpleActual();
+        $object2->{SimpleActual::COLUMN_UNIQUE} = uniqid();
+        $object2->{SimpleActual::COLUMN_IS_IT_ON} = true;
+        $object2->save();
+        $this->assertEquals($object2->{SimpleActual::COLUMN_IS_IT_ON}, 1);
+    }
 
-	public function testUnbufferedSql()
-	{
-		$objects = SimpleActual::getAll(null, false, null, null, false);
+    public function testUnbufferedSql()
+    {
+        $objects = SimpleActual::getAll(null, false, null, null, false);
 
-		$this->assertEquals(count($objects), 3);
-	}
+        $this->assertEquals(count($objects), 3);
+    }
 
-	public function testProtectedFields()
-	{
-		$object = new SimpleActual();
-		$created1 = $object->created;
-		$updated1 = $object->updated;
+    public function testProtectedFields()
+    {
+        $object = new SimpleActual();
+        $created1 = $object->created;
+        $updated1 = $object->updated;
 
-		$object->save();
-		$created2 = $object->created;
-		$updated2 = $object->updated;
+        $object->save();
+        $created2 = $object->created;
+        $updated2 = $object->updated;
 
-		$this->assertSame(1, preg_match(Util::DATETIME_REGEX, $created2), 'Not valid datetime string');
-		$this->assertNotEquals($created1, $created2);
-		$this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated2), 'Not valid datetime string');
-		$this->assertNotEquals($updated1, $updated2);
+        $this->assertSame(1, preg_match(Util::DATETIME_REGEX, $created2), 'Not valid datetime string');
+        $this->assertNotEquals($created1, $created2);
+        $this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated2), 'Not valid datetime string');
+        $this->assertNotEquals($updated1, $updated2);
 
-		sleep(1);
-		$object->unique = uniqid();
-		$object->save();
-		$created3 = $object->created;
-		$updated3 = $object->updated;
+        sleep(1);
+        $object->unique = uniqid();
+        $object->save();
+        $created3 = $object->created;
+        $updated3 = $object->updated;
 
-		$this->assertEquals($created2, $created3);
-		$this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated3), 'Not valid datetime string');
-		$this->assertGreaterThan($updated2, $updated3);
-	}
+        $this->assertEquals($created2, $created3);
+        $this->assertSame(1, preg_match(Util::DATETIME_REGEX, $updated3), 'Not valid datetime string');
+        $this->assertGreaterThan($updated2, $updated3);
+    }
 
-	public function testProtectedFieldsOverwrite()
-	{
-		$newDate = '2000-01-01 13:37:00';
+    public function testProtectedFieldsOverwrite()
+    {
+        $newDate = '2000-01-01 13:37:00';
 
-		$object = new SimpleActual();
-		$object->created = $newDate;
-		$object->updated = $newDate;
-		$object->save();
+        $object = new SimpleActual();
+        $object->created = $newDate;
+        $object->updated = $newDate;
+        $object->save();
 
-		$this->assertEquals($newDate, $object->created);
-		$this->assertEquals($newDate, $object->updated);
+        $this->assertEquals($newDate, $object->created);
+        $this->assertEquals($newDate, $object->updated);
 
-		$newDate = '2000-01-02 13:37:00';
+        $newDate = '2000-01-02 13:37:00';
 
-		$object->created = $newDate;
-		$object->updated = $newDate;
-		$object->save();
+        $object->created = $newDate;
+        $object->updated = $newDate;
+        $object->save();
 
-		$this->assertEquals($newDate, $object->created);
-		$this->assertEquals($newDate, $object->updated);
-	}
+        $this->assertEquals($newDate, $object->created);
+        $this->assertEquals($newDate, $object->updated);
+    }
 }

--- a/tests/Util.php
+++ b/tests/Util.php
@@ -3,6 +3,8 @@ namespace tests;
 
 class Util
 {
+	public const DATETIME_REGEX = '/^[12]\\d{3}-(?:0[1-9]|1[012])-(?:[0-2]\\d|3[01]) (?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$/';
+
 	/**
 	  * Get memcached object with server added
 	  * @return \Memcached
@@ -13,7 +15,7 @@ class Util
 		$memcache->addServer($_SERVER['MEMCACHE_HOST'], 11211);
 		return $memcache;
 	}
-	
+
 	/**
 	  * Get PDO object
 	  * @return \PDO

--- a/tests/Util.php
+++ b/tests/Util.php
@@ -1,29 +1,30 @@
 <?php
+
 namespace tests;
 
 class Util
 {
-	public const DATETIME_REGEX = '/^[12]\\d{3}-(?:0[1-9]|1[012])-(?:[0-2]\\d|3[01]) (?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$/';
+    public const DATETIME_REGEX = '/^[12]\\d{3}-(?:0[1-9]|1[012])-(?:[0-2]\\d|3[01]) (?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d$/';
 
-	/**
-	  * Get memcached object with server added
-	  * @return \Memcached
-	  */
-	public static function getMemcache()
-	{
-		$memcache = new \Memcached();
-		$memcache->addServer($_SERVER['MEMCACHE_HOST'], 11211);
-		return $memcache;
-	}
+    /**
+      * Get memcached object with server added
+      * @return \Memcached
+      */
+    public static function getMemcache()
+    {
+        $memcache = new \Memcached();
+        $memcache->addServer($_SERVER['MEMCACHE_HOST'], 11211);
+        return $memcache;
+    }
 
-	/**
-	  * Get PDO object
-	  * @return \PDO
-	  */
-	public static function getConnection()
-	{
-		$pdo = new \PDO('mysql:host='.$_SERVER['MYSQL_HOST'], $_SERVER['MYSQL_USERNAME'], $_SERVER['MYSQL_PASSWD']);
-		$pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
-		return $pdo;
-	}
+    /**
+      * Get PDO object
+      * @return \PDO
+      */
+    public static function getConnection()
+    {
+        $pdo = new \PDO('mysql:host=' . $_SERVER['MYSQL_HOST'], $_SERVER['MYSQL_USERNAME'], $_SERVER['MYSQL_PASSWD']);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        return $pdo;
+    }
 }

--- a/tests/classes/Bar.php
+++ b/tests/classes/Bar.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace tests\classes;
 
 class Bar extends FooBar
 {
-	const TABLE = 'bar';
+    public const TABLE = 'bar';
 
-	const COLUMN_PRIMARY_KEY = 'bar_id';
+    public const COLUMN_PRIMARY_KEY = 'bar_id';
 }

--- a/tests/classes/CompoundActual.php
+++ b/tests/classes/CompoundActual.php
@@ -13,6 +13,7 @@ class CompoundActual extends \Gyde\Mom\Compound
 	const COLUMN_KEY2 = 'key2';
 	const COLUMN_KEY3 = 'key3';
 	const COLUMN_DEFAULT_VALUE = 'state';
+	const COLUMN_CREATED = 'created';
 	const COLUMN_UPDATED = 'updated';
 	const COLUMN_UNIQUE = 'unique';
 

--- a/tests/classes/CompoundActual.php
+++ b/tests/classes/CompoundActual.php
@@ -1,35 +1,36 @@
 <?php
+
 namespace tests\classes;
 
 class CompoundActual extends \Gyde\Mom\Compound
 {
-	const DB = 'mom';
-	const TABLE = 'mom_compound_test';
+    public const DB = 'mom';
+    public const TABLE = 'mom_compound_test';
 
-	const USE_STATIC_CACHE = TRUE;
+    public const USE_STATIC_CACHE = true;
 
-	const COLUMN_COMPOUND_KEYS = 'key1,key2,key3';
-	const COLUMN_KEY1 = 'key1';
-	const COLUMN_KEY2 = 'key2';
-	const COLUMN_KEY3 = 'key3';
-	const COLUMN_DEFAULT_VALUE = 'state';
-	const COLUMN_CREATED = 'created';
-	const COLUMN_UPDATED = 'updated';
-	const COLUMN_UNIQUE = 'unique';
+    public const COLUMN_COMPOUND_KEYS = 'key1,key2,key3';
+    public const COLUMN_KEY1 = 'key1';
+    public const COLUMN_KEY2 = 'key2';
+    public const COLUMN_KEY3 = 'key3';
+    public const COLUMN_DEFAULT_VALUE = 'state';
+    public const COLUMN_CREATED = 'created';
+    public const COLUMN_UPDATED = 'updated';
+    public const COLUMN_UNIQUE = 'unique';
 
-	const STATE_READY = 'READY';
-	const STATE_SET = 'SET';
-	const STATE_GO = 'GO';
+    public const STATE_READY = 'READY';
+    public const STATE_SET = 'SET';
+    public const STATE_GO = 'GO';
 
-	public static function getByUnique($unique)
-	{
-		$where = '`'.self::COLUMN_UNIQUE.'` = '.self::escapeStatic($unique);
-		return self::getOne($where);
-	}
+    public static function getByUnique($unique)
+    {
+        $where = '`' . self::COLUMN_UNIQUE . '` = ' . self::escapeStatic($unique);
+        return self::getOne($where);
+    }
 
-	public static function getByState($state)
-	{
-		$where = '`'.self::COLUMN_DEFAULT_VALUE.'` = '.self::escapeStatic($state);
-		return self::getAllByWhere($where);
-	}
+    public static function getByState($state)
+    {
+        $where = '`' . self::COLUMN_DEFAULT_VALUE . '` = ' . self::escapeStatic($state);
+        return self::getAllByWhere($where);
+    }
 }

--- a/tests/classes/DefaultActual.php
+++ b/tests/classes/DefaultActual.php
@@ -1,20 +1,21 @@
 <?php
+
 namespace tests\classes;
 
 class DefaultActual extends \Gyde\Mom\Simple
 {
-	const DB = 'mom';
-	const TABLE = 'mom_default_test';
+    public const DB = 'mom';
+    public const TABLE = 'mom_default_test';
 
-	const USE_STATIC_CACHE = TRUE;
-	const USE_MEMCACHE = TRUE;
+    public const USE_STATIC_CACHE = true;
+    public const USE_MEMCACHE = true;
 
-	const COLUMN_PRIMARY_KEY = 'primary_key';
-	const COLUMN_DEFAULT_VALUE = 'state';
-	const COLUMN_UPDATED = 'updated';
-	const COLUMN_UNIQUE = 'unique';
+    public const COLUMN_PRIMARY_KEY = 'primary_key';
+    public const COLUMN_DEFAULT_VALUE = 'state';
+    public const COLUMN_UPDATED = 'updated';
+    public const COLUMN_UNIQUE = 'unique';
 
-	const STATE_READY = 'READY';
-	const STATE_SET = 'SET';
-	const STATE_GO = 'GO';
+    public const STATE_READY = 'READY';
+    public const STATE_SET = 'SET';
+    public const STATE_GO = 'GO';
 }

--- a/tests/classes/Foo.php
+++ b/tests/classes/Foo.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace tests\classes;
 
 class Foo extends FooBar
 {
-	const TABLE = 'foo';
+    public const TABLE = 'foo';
 
-	const COLUMN_PRIMARY_KEY = 'foo_id';
+    public const COLUMN_PRIMARY_KEY = 'foo_id';
 }

--- a/tests/classes/FooBar.php
+++ b/tests/classes/FooBar.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace tests\classes;
 
 class FooBar extends \Gyde\Mom\Simple

--- a/tests/classes/SimpleActual.php
+++ b/tests/classes/SimpleActual.php
@@ -10,6 +10,7 @@ namespace tests\classes; class SimpleActual extends \Gyde\Mom\Simple
 	const COLUMN_PRIMARY_KEY = 'primary_key';
 	const COLUMN_DEFAULT_VALUE = 'state';
 	const COLUMN_CREATED = 'created';
+	const COLUMN_UPDATED = 'updated';
 	const COLUMN_IS_IT_ON = 'is_it_on';
 	const COLUMN_UNIQUE = 'unique';
 

--- a/tests/classes/SimpleActual.php
+++ b/tests/classes/SimpleActual.php
@@ -1,45 +1,48 @@
 <?php
-namespace tests\classes; class SimpleActual extends \Gyde\Mom\Simple
+
+namespace tests\classes;
+
+class SimpleActual extends \Gyde\Mom\Simple
 {
-	const DB = 'mom';
-	const TABLE = 'mom_simple_test';
+    public const DB = 'mom';
+    public const TABLE = 'mom_simple_test';
 
-	const USE_STATIC_CACHE = TRUE;
-	const USE_MEMCACHE = TRUE;
+    public const USE_STATIC_CACHE = true;
+    public const USE_MEMCACHE = true;
 
-	const COLUMN_PRIMARY_KEY = 'primary_key';
-	const COLUMN_DEFAULT_VALUE = 'state';
-	const COLUMN_CREATED = 'created';
-	const COLUMN_UPDATED = 'updated';
-	const COLUMN_IS_IT_ON = 'is_it_on';
-	const COLUMN_UNIQUE = 'unique';
+    public const COLUMN_PRIMARY_KEY = 'primary_key';
+    public const COLUMN_DEFAULT_VALUE = 'state';
+    public const COLUMN_CREATED = 'created';
+    public const COLUMN_UPDATED = 'updated';
+    public const COLUMN_IS_IT_ON = 'is_it_on';
+    public const COLUMN_UNIQUE = 'unique';
 
-	const STATE_READY = 'READY';
-	const STATE_SET = 'SET';
-	const STATE_GO = 'GO';
+    public const STATE_READY = 'READY';
+    public const STATE_SET = 'SET';
+    public const STATE_GO = 'GO';
 
-	public static function getByUnique($unique)
-	{
-		$where = '`'.self::COLUMN_UNIQUE.'` = '.self::escapeStatic($unique);
-		return self::getOne($where);
-	}
+    public static function getByUnique($unique)
+    {
+        $where = '`' . self::COLUMN_UNIQUE . '` = ' . self::escapeStatic($unique);
+        return self::getOne($where);
+    }
 
-	public static function getByUniqueMemcached($unique)
-	{
+    public static function getByUniqueMemcached($unique)
+    {
         $selector = self::COLUMN_UNIQUE;
         if (($entry = self::getCacheEntry($selector)) !== false) {
             return $entry;
         }
 
-		$where = '`'.self::COLUMN_UNIQUE.'` = '.self::escapeStatic($unique);
-		$object = self::getOne($where);
+        $where = '`' . self::COLUMN_UNIQUE . '` = ' . self::escapeStatic($unique);
+        $object = self::getOne($where);
 
-		self::setCacheEntry($selector, $object);
-	}
+        self::setCacheEntry($selector, $object);
+    }
 
-	public static function getByState($state)
-	{
-		$where = '`'.self::COLUMN_DEFAULT_VALUE.'` = '.self::escapeStatic($state);
-		return self::getAllByWhere($where);
-	}
+    public static function getByState($state)
+    {
+        $where = '`' . self::COLUMN_DEFAULT_VALUE . '` = ' . self::escapeStatic($state);
+        return self::getAllByWhere($where);
+    }
 }

--- a/tests/classes/SimpleActual2.php
+++ b/tests/classes/SimpleActual2.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace tests\classes;
 
 class SimpleActual2 extends SimpleActual


### PR DESCRIPTION
Done cause sometimes we need to set an autoupdate field to a specific value.
Also forces the use of helper method describe rather than encourage use of an array that may or may not be set.