### PR TITLE
Fixed bugs in compound use

### DIFF
--- a/src/Base.php
+++ b/src/Base.php
@@ -460,6 +460,7 @@ abstract class Base
       * Caches model in static cache and in Memcache(if enabled)
       * Used when creating new objects, for default values and field info
       * Entry in memcache will be keyed using classname and CLASS_REVISION
+      * @throws BaseException
       * @return array<string, string>
       */
     protected static function describe()

--- a/src/BaseException.php
+++ b/src/BaseException.php
@@ -43,6 +43,9 @@ class BaseException extends Exception
     public const GET_SELECTOR_NOT_DEFINED = 11;
     public const MESSAGE_11 = 'A static getSelector() method must be defined in classes extending Base';
 
+    public const COMPOUND_KEY_AUTO_INCREMENT = 12;
+    public const MESSAGE_12 = 'MOM does not support tables with compound keys that use auto increment';
+
     public const OBJECT_NOT_SAVED = 100;
     public const MESSAGE_100 = 'Object could not be saved (created/updated)';
 

--- a/src/Compound.php
+++ b/src/Compound.php
@@ -67,7 +67,7 @@ class Compound extends Base
             $ids[$key] = $this->$key;
         }
 
-        if (($row = self::getRowByIds($ids)) === null) {
+        if (($row = self::getRowByIds($ids)) == false) {
             throw new BaseException(BaseException::OBJECT_NOT_UPDATED, get_called_class() . '->' . __FUNCTION__ . ' failed to update object with data from database');
         }
 
@@ -169,7 +169,7 @@ class Compound extends Base
       * Get mysql row by primary key
       * @param mixed $id escaped
       * @throws MySQLException
-      * @return resource(mysql resource) or null on failure
+      * @return resource(mysql resource) or false on failure
       */
     private function getRowByIds($ids)
     {
@@ -184,7 +184,7 @@ class Compound extends Base
       * Get mysql row by primary key
       * @param mixed $id escaped
       * @throws MySQLException
-      * @return resource(mysql resource) or null on failure
+      * @return resource(mysql resource) or false on failure
       */
     private static function getRowByIdsStatic($ids)
     {
@@ -199,6 +199,7 @@ class Compound extends Base
       * Get object key pairs
       * Returns mysql field and value string
       * Several rows of pairs like these: `field` = 'value'
+      * @throws BaseException
       * @return string[]
       */
     private function getKeyPairs()
@@ -206,6 +207,9 @@ class Compound extends Base
         $wheres = [];
         $description = static::describe();
         foreach (self::getCompoundKeys() as $key) {
+            if ($description[$key]['Extra'] == 'auto_increment') {
+                throw new BaseException(BaseException::COMPOUND_KEY_AUTO_INCREMENT, get_called_class() . ' uses a table with a compound key, where one of the fields is set to auto increment, please use Simple instead.');
+            }
             if (!isset($this->$key)) {
                 throw new BaseException(BaseException::COMPOUND_KEY_MISSING_VALUE, get_called_class() . '->' . __FUNCTION__ . ' failed to save object to database, ' . $key . ' is not set on object');
             }

--- a/tests/CompoundTest.php
+++ b/tests/CompoundTest.php
@@ -3,6 +3,8 @@
 namespace tests;
 
 use tests\classes\CompoundActual;
+use tests\classes\CompoundAutoIncrement;
+use Gyde\Mom\BaseException;
 
 class CompoundTest extends \PHPUnit\Framework\TestCase
 {
@@ -18,6 +20,7 @@ class CompoundTest extends \PHPUnit\Framework\TestCase
             self::$connection = Util::getConnection();
             \Gyde\Mom\Base::setConnection(self::$connection, true);
             $sqls[] = 'DROP TABLE IF EXISTS ' . CompoundActual::DB . '.' . CompoundActual::TABLE . ';';
+            $sqls[] = 'DROP TABLE IF EXISTS ' . CompoundAutoIncrement::DB . '.' . CompoundAutoIncrement::TABLE . ';';
             $sqls[] = 'CREATE TABLE ' . CompoundActual::DB . '.' . CompoundActual::TABLE . ' (' .
                 ' `' . CompoundActual::COLUMN_KEY1 . '` INT(10) UNSIGNED NOT NULL' .
                 ', `' . CompoundActual::COLUMN_KEY2 . '` INT(10) UNSIGNED NOT NULL' .
@@ -28,6 +31,12 @@ class CompoundTest extends \PHPUnit\Framework\TestCase
                 ', `' . CompoundActual::COLUMN_UNIQUE . '` VARCHAR(32) CHARACTER SET ascii UNIQUE' .
                 ', PRIMARY KEY (`' . CompoundActual::COLUMN_KEY1 . '`,`' . CompoundActual::COLUMN_KEY2 . '`,`' . CompoundActual::COLUMN_KEY3 . '`)' .
                 ') ENGINE = MYISAM;';
+            $sqls[] = 'CREATE TABLE ' . CompoundAutoIncrement::DB . '.' . CompoundAutoIncrement::TABLE . ' (' .
+            ' `' . CompoundAutoIncrement::COLUMN_KEY1 . '` INT(10) UNSIGNED NOT NULL AUTO_INCREMENT' .
+            ', `' . CompoundAutoIncrement::COLUMN_KEY2 . '` INT(10) UNSIGNED NOT NULL' .
+            ', `' . CompoundAutoIncrement::COLUMN_KEY3 . '` INT(10) UNSIGNED NOT NULL' .
+            ', PRIMARY KEY (`' . CompoundAutoIncrement::COLUMN_KEY1 . '`,`' . CompoundAutoIncrement::COLUMN_KEY2 . '`,`' . CompoundAutoIncrement::COLUMN_KEY3 . '`)' .
+            ') ENGINE = MYISAM;';
 
             foreach ($sqls as $sql) {
                 $res = self::$connection->exec($sql);
@@ -202,5 +211,16 @@ class CompoundTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($newDate, $object->created);
         $this->assertEquals($newDate, $object->updated);
+    }
+
+    public function testSaveAutoIncrement()
+    {
+        $this->expectException(BaseException::class);
+        $this->expectExceptionCode(12);
+        $object1 = new CompoundAutoIncrement(self::$connection);
+        $object1->key1 = 42;
+        $object1->key2 = 'test';
+        $object1->key3 = '';
+        $object1->save();
     }
 }

--- a/tests/classes/CompoundAutoIncrement.php
+++ b/tests/classes/CompoundAutoIncrement.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace tests\classes;
+
+class CompoundAutoIncrement extends \Gyde\Mom\Compound
+{
+    public const DB = 'mom';
+    public const TABLE = 'mom_compound_auto_increment_test';
+
+    public const USE_STATIC_CACHE = true;
+
+    public const COLUMN_COMPOUND_KEYS = 'key1,key2,key3';
+    public const COLUMN_KEY1 = 'key1';
+    public const COLUMN_KEY2 = 'key2';
+    public const COLUMN_KEY3 = 'key3';
+}


### PR DESCRIPTION
Changed Compound::getRowByIds to return null on failure, to stay consistent.
Added auto_increment check on tables with compound key. Added is_numeric check on Base::escapeObjectPair to ensure data being the right type.
Added BaseExceptions COMPOUND_KEY_AUTO_INCREMENT, and KEY_TYPES_NOT_MATCH, to use with the previous two additions.